### PR TITLE
A possible fix for orca #133 by changing how paths are parsed; …

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -54,10 +54,10 @@
 <target name="install" description="Install flukes onto specified host and unpack for JNLP use">
 	<property name="flukes.zip" value="flukes-0.7-SNAPSHOT.zip"/>
 	<property name="flukes.host" value="geni-images.renci.org"/>
-	<property name="flukes.dir" value="/images/webstart/0.7-SNAPSHOT"/>
 <!--
-	<property name="flukes.dir" value="/images/webstart"/>
+	<property name="flukes.dir" value="/images/webstart/0.7-SNAPSHOT"/>
 -->
+	<property name="flukes.dir" value="/images/webstart"/>
 	<description>Install flukes onto ${flukes.host} and unpack for JNLP use</description>
 	<scp file="target/${flukes.zip}" todir="${user.name}@${flukes.host}:${flukes.dir}" keyfile="${user.home}/.ssh/id_dsa" />
 	<sshexec host="${flukes.host}" username="${user.name}" keyfile="${user.home}/.ssh/id_dsa" command="cd ${flukes.dir}; unzip -o ${flukes.zip}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
 		<dependency>
 			<groupId>orca</groupId>
 			<artifactId>ndl</artifactId>
-			<version>5.1.5-SNAPSHOT</version>
+			<version>5.2.2-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>xml-apis</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,21 +36,32 @@
 		<!-- location of signing keystore for jnlp -->
 		<maven.build.timestamp.format>MM/dd/yyyy HH:mm</maven.build.timestamp.format>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<orca.snap.repository.id>geni-orca-snapshot</orca.snap.repository.id>
+        <orca.rel.repository.id>geni-orca-release</orca.rel.repository.id>
+        <orca.lib.repository.id>geni-orca-libs</orca.lib.repository.id>
+        <orca.snap.repository.url>http://ci-dev.renci.org/nexus/content/repositories/geni-orca-snapshot/</orca.snap.repository.url>
+        <orca.rel.repository.url>http://ci-dev.renci.org/nexus/content/repositories/geni-orca-release/</orca.rel.repository.url>
+        <orca.lib.repository.url>http://ci-dev.renci.org/nexus/content/repositories/geni-orca-libs</orca.lib.repository.url>
 	</properties>
-	<repositories>
-		<repository>
-			<id>geni-orca-snapshot</id>
-			<name>ORCA Snapshots repo</name>
-			<url>http://ci-dev.renci.org/nexus/content/repositories/geni-orca-snapshot</url>
+    <repositories>
+     	<repository>
+        	<id>${orca.snap.repository.id}</id>
+			<name>Orca Project Maven Snapshot Repository</name>
+ 			<url>${orca.snap.repository.url}</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>
 			</snapshots>
 		</repository>
 		<repository>
-			<id>geni-orca-libs</id>
+			<id>${orca.rel.repository.id}</id>
+			<name>Orca Project Maven Release Repository</name>
+			<url>${orca.rel.repository.url}</url>
+		</repository>
+		<repository>
+			<id>${orca.lib.repository.id}</id>
 			<name>Orca Project Maven Repository</name>
-			<url>http://ci-dev.renci.org/nexus/content/repositories/geni-orca-libs</url>
+			<url>${orca.lib.repository.url}</url>
 		</repository>
 	</repositories>
 	<build>
@@ -302,7 +313,7 @@
 		<dependency>
 			<groupId>orca</groupId>
 			<artifactId>ndl</artifactId>
-			<version>5.2.2-SNAPSHOT</version>
+			<version>5.2.1</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>xml-apis</artifactId>

--- a/src/main/java/orca/flukes/ndl/ManifestLoader.java
+++ b/src/main/java/orca/flukes/ndl/ManifestLoader.java
@@ -854,7 +854,7 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 					Resource second = pIter.next();
 					OrcaNode firstNode = nodes.get(getTrueName(first));
 					OrcaNode secondNode = nodes.get(getTrueName(second));
-					System.out.println("first " + getTrueName(first) + " and second " + getTrueName(second) + " " + firstNode + "/" + secondNode);
+					//System.out.println("first " + getTrueName(first) + " and second " + getTrueName(second) + " " + firstNode + "/" + secondNode);
 					if ((firstNode == null) || (secondNode == null)) {
 						break;
 					}

--- a/src/main/java/orca/flukes/ndl/ManifestLoader.java
+++ b/src/main/java/orca/flukes/ndl/ManifestLoader.java
@@ -827,25 +827,34 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 			GUI.logger().debug("Printing paths");
 			for (List<Resource> p: paths) {
 				StringBuilder sb =  new StringBuilder();
-				sb.append("   Path: ");
+				sb.append("   Path (len: " + p.size() + ") ");
 				for (Resource r: p) {
 					sb.append(r + " ");
 				}
+				
 				GUI.logger().debug(sb.toString());
 				
 				Iterator<Resource> pIter = p.iterator();
 				
 				Resource first = pIter.next();
+				if (NdlCommons.isStitchingNodeInManifest(first)) {
+					// skip one more because stitch node paths have node-node-link-node-link-node structure
+					// rather than node-link-node-link-node structure /ib 12/7/17
+					first = pIter.next();
+				}
 				if (first == null)
 					continue;
+				
 				while(pIter.hasNext()) {
 					// only take nodes, skip links on the path
 					pIter.next();
-					if (!pIter.hasNext())
+					if (!pIter.hasNext()) {
 						break;
+					}
 					Resource second = pIter.next();
 					OrcaNode firstNode = nodes.get(getTrueName(first));
 					OrcaNode secondNode = nodes.get(getTrueName(second));
+					System.out.println("first " + getTrueName(first) + " and second " + getTrueName(second) + " " + firstNode + "/" + secondNode);
 					if ((firstNode == null) || (secondNode == null)) {
 						break;
 					}


### PR DESCRIPTION
This changes how the path is parsed by skipping additional element when stitchport is detected. Should not affect any other situation. 

Needs cleaning up -  I just want consensus on the solution. 

Regular paths go node-link-node-link-node. Stitchport paths go port-node-link-node-link-node. I need to skip links as they are not shown. 