### PR TITLE
Getting rid of duplicate links based on sameAs statements in manifest…

### DIFF
--- a/src/main/java/orca/flukes/ndl/ManifestLoader.java
+++ b/src/main/java/orca/flukes/ndl/ManifestLoader.java
@@ -233,12 +233,12 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 		String ifaceName = getTrueName(iface);
 		GUI.logger().debug("Considering adding interface " + ifaceName + " to the list");
 		
-		Resource sameInt = NdlCommons.getSameAsResource(iface);
-		if (sameInt != null) {
-			GUI.logger().debug("Interface " + iface + " same as " + sameInt);
+		Resource sameIface = NdlCommons.getSameAsResource(iface);
+		if (sameIface != null) {
+			GUI.logger().debug("Interface " + iface + " same as " + sameIface);
 			// add to the set of duplicates and remove any previous copies
-			sameAs.add(sameInt);
-			interfaceToNode.remove(getTrueName(sameInt));
+			sameAs.add(sameIface);
+			interfaceToNode.remove(getTrueName(sameIface));
 		} 
 		// we don't need interfaces to which 'sameAs' points
 		if (sameAs.contains(iface))

--- a/src/main/java/orca/flukes/ndl/ManifestLoader.java
+++ b/src/main/java/orca/flukes/ndl/ManifestLoader.java
@@ -82,6 +82,7 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 
 	private static final String NOTICE_GUID_PATTERN = "^Reservation\\s+([a-zA-Z0-9-]+)\\s+.*(\\s+.*)*$";
 	private Map<String, List<OrcaNode>> interfaceToNode = new HashMap<String, List<OrcaNode>>();
+	private Set<Resource> sameAs = new HashSet<>();
 	private Map<String, OrcaNode> nodes = new HashMap<String, OrcaNode>();
 	private Map<String, OrcaLink> links = new HashMap<String, OrcaLink>();
 	boolean requestPhase = true;
@@ -226,8 +227,6 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 		}
 		return rname;
 	}
-	
-	Set<Resource> sameAs = new HashSet<>();
 	
 	private void addNodeToInterface(Resource iface, OrcaNode n) {
 


### PR DESCRIPTION
… for interfaces

RDF for manifest has owl:sameAs statements which can be used to filter out request interfaces not needed in the visualization. This code filters them out. 