### PR TITLE
Added Horizon properties on VMs and bandwidth on CrossConnects to the text property view

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,5 +1,9 @@
 Flukes Release Notes:
 ---------------------
+06/04/19:
+- Adding Horizon login details to VMs
+- Fixed bandwidth view on cross connect objects
+
 01/02/18:
 - Fixing Cancel button behavior for SSH key insertion
 

--- a/build.xml
+++ b/build.xml
@@ -52,7 +52,7 @@
 </target>
 
 <target name="install" description="Install flukes onto specified host and unpack for JNLP use">
-	<property name="flukes.zip" value="flukes-0.7.3.zip"/>
+	<property name="flukes.zip" value="flukes-0.7.4.zip"/>
 	<property name="flukes.host" value="geni-images.renci.org"/>
 <!--
 	<property name="flukes.dir" value="/images/webstart/0.7-SNAPSHOT"/>

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
 		<dependency>
 			<groupId>orca</groupId>
 			<artifactId>ndl</artifactId>
-			<version>5.2.1</version>
+			<version>5.4.10-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>xml-apis</artifactId>
@@ -417,7 +417,7 @@
 		<dependency>
 			<groupId>orca.core</groupId>
 			<artifactId>util</artifactId>
-			<version>5.2.1</version>
+			<version>5.4.10-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bcprov-ext-jdk15</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>orca</groupId>
 	<artifactId>flukes</artifactId>
-	<version>0.7.3</version>
+	<version>0.7.4</version>
 	<name>FLUKES</name>
 	<description>FLUKES - ORCA NDL graph editor</description>
 	<url>http://geni-images.renci.org/webstart</url>

--- a/src/main/java/orca/flukes/OrcaCrossconnect.java
+++ b/src/main/java/orca/flukes/OrcaCrossconnect.java
@@ -109,6 +109,7 @@ public class OrcaCrossconnect extends OrcaNode {
 		viewText += "\nReservation notice: " + (resNotice != null ? resNotice : NOT_SPECIFIED);
 		if (label != null)
 			viewText += "\nLabel/Tag: " + label;
+		viewText += "\nBandwidth: " + bandwidth;
 		if (interfaces.size() > 0) {
 			viewText += "\nInterfaces: ";
 			for(Entry<OrcaLink, String> e: interfaces.entrySet()) {

--- a/src/main/java/orca/flukes/OrcaNode.java
+++ b/src/main/java/orca/flukes/OrcaNode.java
@@ -66,7 +66,7 @@ import orca.flukes.ui.IconOutline;
 
 public class OrcaNode extends OrcaResource {
 
-	protected static final String NOT_SPECIFIED = "Not specified";
+    protected static final String NOT_SPECIFIED = "Not specified";
 	public static final String NODE_NETMASK="32";
 	
 	protected String image = null;
@@ -89,6 +89,9 @@ public class OrcaNode extends OrcaResource {
 	protected String postBootScript = null;
 	// list of open ports
 	protected String openPorts = null;
+	
+	// Horizon URL, name and password (if available)
+	protected String horizonURL = null, horizonName = null, horizonPass = null;
 	
 	protected Set<OrcaNode> dependencies = new HashSet<OrcaNode>();
 	
@@ -380,6 +383,14 @@ public class OrcaNode extends OrcaResource {
 		return null;
 	}
 	
+	// if Horizon is available
+	public void setHorizonDetails(String url, String name, String pass) {
+	   
+	    horizonURL = url;
+	    horizonName = name;
+	    horizonPass = pass;
+	}
+	
 	public String getPortsList() {
 		return openPorts;
 	}
@@ -425,11 +436,20 @@ public class OrcaNode extends OrcaResource {
 						GUI.getInstance().getPreference(GUI.PrefsEnum.SSH_OPTIONS) + " ");
 				service = service.replaceAll(":", " -p ");
 			} 
-			viewText += service + "\n";
+			viewText += "\t" + service + "\n";
 		}
+		
 		if (getManagementAccess().size() == 0) {
-			viewText += NOT_SPECIFIED + "\n";
+			viewText += "\t" + NOT_SPECIFIED + "\n";
 		}
+		
+        if (horizonURL != null) {
+            viewText += "\n\nHorizon Access Details:";
+            viewText += "\n\tHorizon URL: " + horizonURL;
+            viewText += "\n\tHorizon Username: " + (horizonName != null ? horizonName : NOT_SPECIFIED);
+            viewText += "\n\tHorizon Password: " + (horizonPass != null ? horizonPass : NOT_SPECIFIED);
+        }
+		
 		viewText += "\n\nInterfaces: ";
 		for(Map.Entry<OrcaLink, Pair<String>> e: addresses.entrySet()) {
 			viewText += "\n\t" + e.getKey().getName() + ": " + e.getValue().getFirst() + "/" + e.getValue().getSecond() + " " + 

--- a/src/main/java/orca/flukes/ndl/ManifestLoader.java
+++ b/src/main/java/orca/flukes/ndl/ManifestLoader.java
@@ -289,6 +289,8 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 		Iterator<Resource> it = interfaces.iterator(); 
 		
 		String label = NdlCommons.getResourceLabel(l);
+		long bw = NdlCommons.getResourceBandwidth(l);
+		GUI.logger().debug("Link Connection: " + l + " with label " + label + " and bw " + bw);
 		
 		// limit to link connections not part of a network connection
 		if (interfaces.size() == 2){
@@ -329,6 +331,7 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 									// degenerate case of a node on a shared vlan
 									OrcaCrossconnect oc = new OrcaCrossconnect(getPrettyName(l));
 									oc.setLabel(label);
+									oc.setBandwidth(bw);
 									oc.setUrl(l.getURI());
 									oc.setDomain(RequestSaver.reverseLookupDomain(NdlCommons.getDomain(l)));
 									nodes.put(getTrueName(l), oc);
@@ -374,6 +377,7 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 			OrcaCrossconnect ml = new OrcaCrossconnect(getPrettyName(l));
 
 			ml.setLabel(label);
+			ml.setBandwidth(bw);
 			ml.setUrl(l.getURI());
 			ml.setReservationNotice(NdlCommons.getResourceReservationNotice(l));
 			ml.setReservationGuid(getGuidFromNotice(ml.getReservationNotice()));
@@ -523,7 +527,7 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 		if (c == null)
 			return;
 
-		GUI.logger().debug("CrossConnect: " + c + " with label " + label);
+		GUI.logger().debug("CrossConnect: " + c + " with label " + label + " and bw " + bw);
 		
 		OrcaCrossconnect oc = new OrcaCrossconnect(getPrettyName(c));
 		oc.setLabel(label);
@@ -674,6 +678,10 @@ public class ManifestLoader implements INdlManifestModelListener, INdlRequestMod
 		// management IP/port access
 		on.setManagementAccess(NdlCommons.getNodeServices(nr));
 		
+		
+		// Horizon details if available
+		on.setHorizonDetails(NdlCommons.getHorizonUrl(nr), 
+		        NdlCommons.getHorizonUserName(nr), NdlCommons.getHorizonUserPwd(nr));
 		// state
 		on.setState(NdlCommons.getResourceStateAsString(nr));
 		


### PR DESCRIPTION
Addresses #26 and #25 with a caveat that bandwidth on *links* is a won't fix, has to do with how things are rendered, however now bandwidth should be properly shown in text view for crossconnects of different types. 